### PR TITLE
Please support RPM's JSITransparentPod.

### DIFF
--- a/TextureReplacer/Personaliser.cs
+++ b/TextureReplacer/Personaliser.cs
@@ -715,9 +715,10 @@ namespace TextureReplacer
       readKerbalsConfigs();
 
       // Check if the srf mod is present.
-      isSfrDetected = AssemblyLoader.loadedAssemblies.Any(a => a.name.StartsWith("sfrPartModules"));
+      isSfrDetected = AssemblyLoader.loadedAssemblies.Any(a => a.name.StartsWith("sfrPartModules")) || 
+                      AssemblyLoader.loadedAssemblies.Any(a => a.name.StartsWith("RasterPropMonitor")) ;
       if (isSfrDetected)
-        Util.log("Detected sfr mod, enabling alternative Kerbal IVA texture replacement");
+        Util.log("Detected sfr mod or RasterPropMonitor, enabling alternative Kerbal IVA texture replacement");
 
       // Save pointer to helmet & visor meshes so helmet removal can restore them.
       foreach (SkinnedMeshRenderer smr


### PR DESCRIPTION
For details see https://github.com/Mihara/RasterPropMonitor/issues/126
and https://github.com/Mihara/RasterPropMonitor/wiki/Part-modules#jsitransparentpod

Consider the source, though, there is probably a more optimal way to do it:
https://github.com/Mihara/RasterPropMonitor/blob/master/RasterPropMonitor/Auxiliary%20modules/JSITransparentPod.cs
