### PR TITLE
Update version file to reflect support of KSP 1.7

### DIFF
--- a/GameData/TextureReplacer/TextureReplacer.version
+++ b/GameData/TextureReplacer/TextureReplacer.version
@@ -15,7 +15,6 @@
   },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,
-    "MINOR": 6,
-    "PATCH": 99
+    "MINOR": 7
   }
 }


### PR DESCRIPTION
The [forum thread](https://forum.kerbalspaceprogram.com/index.php?/topic/96851-*) is currently titled "[1.6.x--1.7.x] TextureReplacer 3.7 (25.1.2019)", implying that KSP 1.7 is supported. This can be indicated programmatically by updating KSP_VERSION_MAX in the online version file.

(This will flow through to CKAN within a few hours of merging.)